### PR TITLE
fix readme: hash required

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ROUTING_KEY = 'example_routing_key'
 client = VictorOps::Client.new api_url: API_URL, routing_key: ROUTING_KEY
 
 # Send a CRITICAL alert
-client.critical 'THE DISK IS FULL!!!'
+client.critical desc: 'THE DISK IS FULL!!!'
 
 # Send a WARNING alert
 client.warn desc: 'Disk is nearing capacity', stats: `df -h`


### PR DESCRIPTION
method requires a hash, not a string, due to `merge` in [this](https://github.com/clok/victor-ops-client/blob/master/lib/victor_ops/client.rb#L94) method.