### PR TITLE
Update rest-client to 2.x to fix ssl cipher issue

### DIFF
--- a/victor_ops-client.gemspec
+++ b/victor_ops-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 1.9.3'
-  s.add_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_dependency 'rest-client', '~> 2.0', '>= 1.8.0'
   s.add_dependency 'awesome_print', '~> 1.6', '>= 1.6.1'
   s.add_dependency 'daybreak', '~> 0.3', '>= 0.3.0'
   s.add_development_dependency "rspec", '~> 3.0'


### PR DESCRIPTION
API requests fail under Ruby >= 2.4.x due to weirdness with openssl1.1. Error message is:

    KeyError: key not found: :ciphers

This is fixed in rest-client 2.x but the gemspec pins to 1.8.x.

See https://github.com/rest-client/rest-client/issues/569 for background.

Confirmed this works under Ruby 2.5.1 and rest-client 2.0.2.